### PR TITLE
Fix error can't open image files in Python3.

### DIFF
--- a/recognizer/crnn/lib/create_lmdb_dataset.py
+++ b/recognizer/crnn/lib/create_lmdb_dataset.py
@@ -1,4 +1,3 @@
-
 import lmdb
 import cv2
 import numpy as np
@@ -26,7 +25,9 @@ def checkImageIsValid(imageBin):
 
 def writeCache(env, cache):
     with env.begin(write=True) as txn:
-        for k, v in cache.items():
+        for _k, _v in cache.items():
+            k = _k.encode() if type(_k) == str else _k
+            v = _v.encode() if type(_v) == str else _v
             txn.put(k, v)
 
 
@@ -54,7 +55,7 @@ def createDataset(outputPath, imagePathList, labelList, lexiconList=None, checkV
         #     print('%s does not exist' % imagePath)
         #     continue
 
-        with open(imagePath, 'r') as f:
+        with open(imagePath, 'rb') as f:
             imageBin = f.read()
 
         if checkValid:

--- a/recognizer/crnn/lib/dataset.py
+++ b/recognizer/crnn/lib/dataset.py
@@ -60,7 +60,7 @@ class lmdbDataset(Dataset):
                 img = self.transform(img)
 
             label_key = 'label-%09d' % index
-            label = txn.get(label_key.encode())
+            label = txn.get(label_key.encode()).decode()
 
             if self.target_transform is not None:
                 label = self.target_transform(label)

--- a/recognizer/crnn/lib/get_alphabets.py
+++ b/recognizer/crnn/lib/get_alphabets.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+__title__ = ''
+__author__ = 'changxin'
+__mtime__ = '2019/3/14'
+"""
+
+
+def get_alphabets(filelists):
+    a = []
+    for x in filelists:
+        with open(x) as f:
+            strings = f.readlines()
+            string = [y.strip().split(' ')[1] for y in strings]
+            tmp = []
+            for z in ''.join(string):
+                tmp.append(z)
+            a = a + tmp
+    with open('alphabets.py', 'w') as e:
+        e.write("#coding=utf8\n")
+        e.write('\"\"\"' + ''.join(list(set(a))) + '\"\"\"')


### PR DESCRIPTION
1.We tried to use your CRNN network for training, and the Python version we used was 3.7.2,
in the process of generating the LMDB file, I noticed that......an error will occur, Python
3 need to add a "b" flag bit when reading bit type data.
"""
with open(imagePath, 'r') as f:
    imageBin = f.read()

"""

2. I noticed that there was an error when you directly pushed STR into LMDB when I put data
into LMDB.LMDB should only accept data of bytes type, so we have to encode data asbyte type.

3.In the process of reading data from LMDB, since the data read out is bytes type, the
 string operation cannot be carried out directly, and the bytes type decode needs to be
 str.

4.The data sets we used is different form yours, so some of the characters in yout 
"alphabets.pu"cannot be found and cause application error. I wrote a function to
 generate the corresponding "apphabets.py" module according to the data sets wo imprvoe
 compatibility.